### PR TITLE
removing the MaterialApp widget

### DIFF
--- a/lib/intro_slider.dart
+++ b/lib/intro_slider.dart
@@ -519,40 +519,32 @@ class IntroSliderState extends State<IntroSlider>
     }
   }
 
-  @override
+@override
   Widget build(BuildContext context) {
     //Full screen view
     if (shouldHideStatusBar == true) {
       SystemChrome.setEnabledSystemUIOverlays([]);
     }
 
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      locale: Locale(locale ?? 'en'),
-      supportedLocales: [const Locale('en'), const Locale('ar')],
-      localizationsDelegates: [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ],
-      home: DefaultTabController(
+    return Scaffold(
+      body: DefaultTabController(
         length: slides.length,
-        child: Scaffold(
-          body: Stack(
-            children: <Widget>[
-              TabBarView(
-                children: tabs,
-                controller: tabController,
-                physics: isScrollable
-                    ? ScrollPhysics()
-                    : NeverScrollableScrollPhysics(),
-              ),
-              renderBottom(),
-            ],
-          ),
+        child: Stack(
+          children: <Widget>[
+            TabBarView(
+              children: tabs,
+              controller: tabController,
+              physics: isScrollable
+                  ? ScrollPhysics()
+                  : NeverScrollableScrollPhysics(),
+            ),
+            renderBottom(),
+          ],
         ),
       ),
     );
   }
+
 
   Widget buildSkipButton() {
     if (tabController.index + 1 == slides.length) {


### PR DESCRIPTION
The MaterialApp widget should only be added once at the top level, not in a screen in the app. One reason is that MaterialApp includes its own Navigator class ("The MaterialApp configures the top-level Navigator to search for routes in the following order.."). Nesting more than one MaterialApp widget will cause navigation route issues (black screen when performing a pop()). There are also locale concerns with nesting.